### PR TITLE
Bump lib `muqsit/arithmexp` to `0.1.28`

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -7,7 +7,7 @@ projects:
     path: ""
     libs:
       - src: muqsit/arithmexp/arithmexp
-        version: 0.1.27
+        version: 0.1.28
       - src: nhanaz-pm-pl/libBedrock/libBedrock
         version: 0.0.2
 ...

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 ---
 name: Calculator
-version: 0.0.17
+version: 0.0.18
 main: NhanAZ\Calculator\Main
 api: 4.0.0
 


### PR DESCRIPTION
Improved performance of evaluating operator tokens ([`de91e05`](https://github.com/Muqsit/arithmexp/commit/de91e05748623ed2923ab2c3a5b70a1dc4054d4d), [`998ec6a`](https://github.com/Muqsit/arithmexp/commit/998ec6a8ac09e7104fcb76436f602d1facda7817), [`5b40d3c`](https://github.com/Muqsit/arithmexp/commit/5b40d3cfe95e8967b72910bdf43021c0bcacb720), [`4acfe1d`](https://github.com/Muqsit/arithmexp/commit/4acfe1d2160fe172d448b260d6397ca0ff08c5cf), [`3a77909`](https://github.com/Muqsit/arithmexp/commit/3a7790930cb1ed904fa78344d73efae5e061130a))